### PR TITLE
Make sensor itself a date, without time

### DIFF
--- a/custom_components/sensor/hvc.py
+++ b/custom_components/sensor/hvc.py
@@ -115,7 +115,6 @@ class TrashCollectionSchedule(object):
 		self.data = {}
 		for trashDay in data:
 			afvalstroomId = trashDay['afvalstroom_id']
-			pickupDate = datetime.strptime(trashDay['ophaaldatum'], '%Y-%m-%d')
-
-			if afvalstroomId not in self.data and pickupDate.date() >= datetime.now().date():
+			pickupDate = datetime.strptime(trashDay['ophaaldatum'], '%Y-%m-%d').date()
+			if afvalstroomId not in self.data and pickupDate >= datetime.now().date():
 				self.data[afvalstroomId] = pickupDate


### PR DESCRIPTION
Hi,

Me again, I've made another improvement. This change makes the sensor itself a date in home assistant. This makes the automation also a lot simpler. 

i.e. '{{now().strftime("%Y-%m-%d") == (states.sensor.trash_rest.state)}}'